### PR TITLE
Agregar codigo a función para crear trigger anti dll

### DIFF
--- a/functions/Add-tssDropPreventTrigger.ps1
+++ b/functions/Add-tssDropPreventTrigger.ps1
@@ -1,2 +1,34 @@
 ﻿function Add-tssDropPreventTrigger {
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [parameter(Mandatory=$true, ParameterSetName=”FromInnerFx", Position=0)]
+        [object] $PLSDatabase,
+
+        [parameter(Mandatory=$true, ParameterSetName=”Direct", Position=0)]
+        [Validateset('DEV', 'INT', 'QA', 'UAT', 'PERF', 'PROD', 'LOCAL', 'DBA')]
+        [string] $Environment,
+
+        [parameter(Mandatory=$true, ParameterSetName=”Direct", Position=1)]
+        [string] $SubEnvironment,
+
+        [parameter(Mandatory=$true, ParameterSetName=”Direct", Position=2)]
+        [Validateset('PLS','PWB')]
+        [string] $DBType
+    )
+
+    if ($PSCmdlet.ParameterSetName -eq "Direct") {
+        $PLSDatabase = Get-tssDatabase -Environment $Environment -SubEnvironment $SubEnvironment -Database $DBType
+    }
+
+    $tsstoolspath = Split-Path -Path ((Get-Module -ListAvailable tsstools).path) -Parent
+    $ScriptDBTrigger = Join-Path -Path $tsstoolspath -ChildPath "sqlscripts\xpo.disable_ddl_database_trigger.sql"
+    if (Test-Path -Path $ScriptDBTrigger) {
+        if ($PSCmdlet.ShouldProcess($PLSDatabase,"Creando trigger para evitar operaciones DDL")) {
+            Invoke-Sqlcmd -ServerInstance $PLSDatabase.parent.name -Database $PLSDatabase.name -InputFile $ScriptDBTrigger -QueryTimeout 0
+        }
+    }
+    else {
+        Write-Warning "No se encontro el script de creación de trigger para evitar operaciones DDL"
+    }
+
 }

--- a/sqlscripts/xpo.disable_ddl_database_trigger.sql
+++ b/sqlscripts/xpo.disable_ddl_database_trigger.sql
@@ -1,0 +1,32 @@
+IF EXISTS (select * from sys.triggers WHERE name = 'disableDrop' and parent_class_desc ='DATABASE')
+	DROP TRIGGER [disableDrop] ON DATABASE 
+GO
+/****** Object:  DdlTrigger [disableDrop]    Script Date: 17/08/2016 5:09:39 p. m. ******/
+SET ANSI_NULLS ON
+GO
+SET QUOTED_IDENTIFIER ON
+GO
+CREATE TRIGGER [disableDrop] 
+ON DATABASE 
+FOR --DROP_TABLE, 
+DROP_FUNCTION, DROP_PROCEDURE,--, DROP_VIEW
+DROP_TABLE,     create_table,     alter_table,
+create_function,  --alter_function,
+create_procedure, --alter_procedure,
+DROP_VIEW,      create_view      --alter_view
+AS 
+DECLARE @data XML
+SET @data = EVENTDATA()
+DECLARE @schema nvarchar(100)
+SET @schema = @data.value('(/EVENT_INSTANCE/SchemaName)[1]', 'nvarchar(100)')
+--IF IS_MEMBER ('db_owner') = 0 AND @Schema = 'dbo'
+IF user ='tssuser'
+BEGIN
+--RAISERROR ('Only db owner can drop table, function, procedure or view in dbo schema.',10, 1)
+RAISERROR ('Only db owner can drop table, function, procedure in dbo schema.',10, 1)
+ROLLBACK
+END
+GO
+ENABLE TRIGGER [disableDrop] ON DATABASE
+GO
+


### PR DESCRIPTION
Función para crear trigger que evita las operaciones de create y drop. Normalmente solo es para ambientes de DEV.